### PR TITLE
Do not treat char as int pointer

### DIFF
--- a/hosts2zones.c
+++ b/hosts2zones.c
@@ -120,8 +120,7 @@ int main(int argc, const char *argv[])
                            nextword += blanklen(nextword);
 
                            if (*lowercase(word, wl) &&                                 // convert to lowercase, end check if it is a non empty string
-                               (*(int64_t *)word != *(int64_t *)"localhos"             // don't process 'localhost' entries
-                                || *(int16_t *)(word+8) != *(int16_t *)"t") &&
+                               strncmp(word, "localhost", 9) &&			       // don't process 'localhost' entries
                                !findName(domainStore, word, wl))                       // if the entry does not exit in the domain store
                            {                                                           // then create a new one for the given domain name
                               Value value = {Simple, .b = iswhite};

--- a/hosts2zones.c
+++ b/hosts2zones.c
@@ -106,10 +106,9 @@ int main(int argc, const char *argv[])
                          0 < (dl = domainlen(line)) && dl < wl)                        // must contain at least 1 non-leading & non-traling dot
                         word = line, iswhite = false;                                  // simple domain lists are always black lists
                                                                                        // otherwise assume the Hosts file format
-                     else if ((iswhite = *(int64_t *)line == *(int64_t *)"1.1.1.1") || // entries starting with 1.1.1.1 shall be white listed
-                             /*isblack*/ *(int64_t *)line == *(int64_t *)"0.0.0.0"  || // 0.0.0.0 or 127.0.0.1 are black list entries
-                             /*isblack*/ *(int16_t *)line == *(int16_t *)"12" &&
-                                    *(int64_t *)(line+=2) == *(int64_t *)"7.0.0.1")
+                     else if ((iswhite = !strncmp(line, "1.1.1.1", 8)) || 	       // entries starting with 1.1.1.1 shall be white listed
+                             /*isblack*/ !strncmp(line, "0.0.0.0", 8)  || 	       // 0.0.0.0 or 127.0.0.1 are black list entries
+                             /*isblack*/ (!strncmp(line, "127.0.0.1", 10) && (line+=2)))
                         word = line + 8, word += blanklen(word);                       // skip IP address and leading blanks
 
                      if (word)                                                         // only process simple domain entries or entries in Hosts file format

--- a/hosts2zones.c
+++ b/hosts2zones.c
@@ -81,7 +81,7 @@ int main(int argc, const char *argv[])
             char *hosts = allocate(st.st_size + 2, false);
             if (fread(hosts, st.st_size, 1, in) == 1)
             {
-               *(uint16_t *)&hosts[st.st_size] = *(uint16_t *)"\n";                    // guaranteed end of line + end of string at the end of the read-in data
+               hosts[st.st_size] = '\n';                    			       // guaranteed end of line + end of string at the end of the read-in data
 
                bool  iswhite;
                int   dl, ll, wl;


### PR DESCRIPTION
Potential fix for #6. Remove comparisons of strings as int pointers since they cause bus faults on armv6 (and probably armv7 as well) and use `strncmp`. 
A side effect of this change is that entries of the form `localhost.localdomain` are now (correctly, in my opinion) skipped, whereas they weren't before, since I suspect [this comparison](https://github.com/cyclaero/void-zones-tools/blob/baf82af947329fa62b02b9ea9e9d6eefea90ff9e/hosts2zones.c#L125) wasn't working correctly in that case