### PR TITLE
Security: Fixed Unsafe Temp File Usage

### DIFF
--- a/void-zones-update.sh
+++ b/void-zones-update.sh
@@ -27,6 +27,12 @@
 # IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#For use with the local_unbound version (default) of unbound on FreeBSD
+LOCAL_VOID_ZONES_FILE="/var/unbound/local-void.zones"
+
+#For use with the pkg port version of unbound on FreeBSD
+#LOCAL_VOID_ZONES_FILE="/usr/local/etc/unbound/local-void.zones"
+
 
 ### verify the path to the fetch utility
 if [ -e "/usr/bin/fetch" ]; then
@@ -56,10 +62,10 @@ fi
 
 
 ### Updating the void zones
-$FETCH -o "$ZONES_DIR/pgl_void_hosts.txt"     "http://pgl.yoyo.org/as/serverlist.php?hostformat=hosts&showintro=0&useip=0.0.0.0&mimetype=plaintext"
-$FETCH -o "$ZONES_DIR/sowc_void_hosts.txt"    "http://someonewhocares.org/hosts/zero/hosts"
-$FETCH -o "$ZONES_DIR/mvps_void_hosts.txt"    "http://winhelp2002.mvps.org/hosts.txt"
-$FETCH -o "$ZONES_DIR/mdl_void_hosts.txt"     "http://www.malwaredomainlist.com/hostslist/hosts.txt"
+$FETCH -o "$ZONES_DIR/pgl_void_hosts.txt"     "https://pgl.yoyo.org/as/serverlist.php?hostformat=hosts&showintro=0&useip=0.0.0.0&mimetype=plaintext"
+$FETCH -o "$ZONES_DIR/sowc_void_hosts.txt"    "https://someonewhocares.org/hosts/zero/hosts"
+$FETCH -o "$ZONES_DIR/mvps_void_hosts.txt"    "https://winhelp2002.mvps.org/hosts.txt"
+$FETCH -o "$ZONES_DIR/mdl_void_hosts.txt"     "https://www.malwaredomainlist.com/hostslist/hosts.txt"
 $FETCH -o "$ZONES_DIR/away_void_hosts.txt"    "https://adaway.org/hosts.txt"
 $FETCH -o "$ZONES_DIR/ucky_void_host.txt"     "https://raw.githubusercontent.com/FadeMind/hosts.extras/master/UncheckyAds/hosts"
 $FETCH -o "$ZONES_DIR/wintelm_void_hosts.txt" "https://raw.githubusercontent.com/crazy-max/WindowsSpyBlocker/master/data/hosts/spy.txt"
@@ -92,7 +98,9 @@ if [ ! -f "$ZONES_DIR/wintelm_void_hosts.txt" ] ; then
    echo "# No hosts from WindowsSpyBlocker/hosts/spy." > "$ZONES_DIR/wintelm_void_hosts.txt"
 fi
 
-/usr/local/bin/hosts2zones /tmp/local-void.zones \
+TMPFILE=`/usr/bin/mktemp /tmp/local-void.zones.XXXXXXXXXXX` || exit 1
+
+/usr/local/bin/hosts2zones $TMPFILE \
                            "$ZONES_DIR/my_void_hosts.txt" \
                            "$ZONES_DIR/pgl_void_hosts.txt" \
                            "$ZONES_DIR/sowc_void_hosts.txt" \
@@ -104,4 +112,4 @@ fi
                            "$ZONES_DIR/x_void_list.txt" \
                            "$ZONES_DIR/y_void_list.txt" \
                            "$ZONES_DIR/z_void_list.txt" \
-  && /bin/mv /tmp/local-void.zones /var/unbound/local-void.zones
+  && /bin/mv $TMPFILE $LOCAL_VOID_ZONES_FILE && /bin/chmod 644 $LOCAL_VOID_ZONES_FILE


### PR DESCRIPTION
* Moved the local-void.zones file name into a variable so that the location can easily be changed for use with the ports version of unbound under FreeBSD.

* Updated remaining http:// links to https:// links. (This part is duplicate of the pull from njdoyle)

* Fixed unsafe temp file usage: This script is meant to be run as root form cron. The use of a fixed temp filename leads to symlink attacks where an ordinary user can force root to overwrite any file on the system.

Consider for example using the previous code:

A user runs:

> ln -s /bin/sh /tmp/local-void.zones

Now the script is run as root from cron...